### PR TITLE
ignore `onnxruntime-gpu` for macOS and for arm64 CPUs

### DIFF
--- a/InstantID.py
+++ b/InstantID.py
@@ -205,7 +205,7 @@ class InstantIDFaceAnalysis:
     def INPUT_TYPES(s):
         return {
             "required": {
-                "provider": (["CPU", "CUDA", "ROCM"], ),
+                "provider": (["CPU", "CUDA", "ROCM", "CoreML"], ),
             },
         }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 insightface
 onnxruntime
-onnxruntime-gpu
+onnxruntime-gpu; sys_platform != 'darwin' and platform_machine == 'x86_64'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 insightface
 onnxruntime
 onnxruntime-gpu; sys_platform != 'darwin' and platform_machine == 'x86_64'
+onnxruntime-silicon; sys_platform == 'darwin'


### PR DESCRIPTION
clone of this PR: https://github.com/cubiq/PuLID_ComfyUI/pull/72

I hope this little pull request will be useful too.

