### PR TITLE
revert of adding deprecated onnxruntime-silicon package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 insightface
 onnxruntime
 onnxruntime-gpu; sys_platform != 'darwin' and platform_machine == 'x86_64'
-onnxruntime-silicon; sys_platform == 'darwin'


### PR DESCRIPTION
Sorry @cubiq for the PR spam, but we started deploying today on the different systems and the problem arise with python3.12 on M3 Max.

https://github.com/cubiq/PuLID_ComfyUI/pull/72#issuecomment-2375612195

In this message I was advised to add the package "onnxruntime-silicon" - but it is already deprecated and is included by default in the package "onnxruntime"

Here is the message from the author of the package regarding this:

https://github.com/cansik/onnxruntime-silicon/issues/20#issuecomment-2220740825

I am truly sorry for spam and my inattention